### PR TITLE
tests: Fix signals sent to wrong parent process

### DIFF
--- a/tests/close-view/close-layer-shell/main.py
+++ b/tests/close-view/close-layer-shell/main.py
@@ -17,7 +17,7 @@ class WTest(wt.WayfireTest):
         self.wait_for_clients(2)
 
         self.send_signal(pid, signal.SIGKILL)
-        self.wait_for_clients(2)
+        self.wait_ms(150) # Wait for animation to end
 
         if len(self.socket.list_views()) > 0:
             print(self.socket.list_views())

--- a/tests/close-view/close-layer-shell/main.py
+++ b/tests/close-view/close-layer-shell/main.py
@@ -17,7 +17,7 @@ class WTest(wt.WayfireTest):
         pid = self.socket.run('swaylock')["pid"]
         self.wait_for_clients(2)
 
-        os.kill(pid, signal.SIGKILL)
+        self.send_signal(pid, signal.SIGKILL)
         self.wait_for_clients(2)
 
         if len(self.socket.list_views()) > 0:

--- a/tests/close-view/close-layer-shell/main.py
+++ b/tests/close-view/close-layer-shell/main.py
@@ -1,7 +1,6 @@
 #!/bin/env python3
 
 import wftest as wt
-import os
 import signal
 
 def is_gui() -> bool:

--- a/tests/close-view/close-layer-shell/wayfire.ini
+++ b/tests/close-view/close-layer-shell/wayfire.ini
@@ -3,4 +3,4 @@ plugins = ipc stipc animate
 
 [animate]
 fade_enabled_for = all
-fade_duration = 1
+fade_duration = 50

--- a/tests/close-view/wayfire-1856/main.py
+++ b/tests/close-view/wayfire-1856/main.py
@@ -1,7 +1,6 @@
 #!/bin/env python3
 
 import wftest as wt
-import os
 import signal
 
 def is_gui() -> bool:

--- a/tests/close-view/wayfire-1856/main.py
+++ b/tests/close-view/wayfire-1856/main.py
@@ -23,7 +23,7 @@ class WTest(wt.WayfireTest):
         layout = {}
         layout['wleird-slow-ack-configure'] = (0, 0, 500, 500)
         self.socket.layout_views(layout)
-        os.kill(slowack, signal.SIGKILL)
+        self.send_signal(slowack, signal.SIGKILL)
 
         # Wait for transaction to finish
         self.wait_ms(150)

--- a/tests/close-view/wayfire-1874/main.py
+++ b/tests/close-view/wayfire-1874/main.py
@@ -1,7 +1,6 @@
 #!/bin/env python3
 
 import wftest as wt
-import os
 import signal
 
 def is_gui() -> bool:

--- a/tests/close-view/wayfire-1874/main.py
+++ b/tests/close-view/wayfire-1874/main.py
@@ -22,7 +22,7 @@ class WTest(wt.WayfireTest):
         layout['gcs'] = (0, 0, 500, 500)
         self.socket.layout_views(layout)
         self.wait_for_clients()
-        os.kill(pid, signal.SIGKILL)
+        self.send_signal(pid, signal.SIGKILL)
 
         # Wait for transaction to finish
         self.wait_ms(400)

--- a/tests/gui/expo-basic/main.py
+++ b/tests/gui/expo-basic/main.py
@@ -32,7 +32,7 @@ class WTest(wt.WayfireTest):
         if error := self.take_screenshot('expo-start'):
             return wt.Status.CRASHED, error
 
-        os.kill(pid, signal.SIGUSR1);
+        self.send_signal(pid, signal.SIGUSR1);
         self.wait_for_clients(2) # Wait for color-switcher to change color
         if error := self.take_screenshot('expo-damage'):
             return wt.Status.CRASHED, error

--- a/tests/gui/expo-basic/main.py
+++ b/tests/gui/expo-basic/main.py
@@ -1,7 +1,6 @@
 #!/bin/env python3
 
 import wftest as wt
-import os
 import signal
 
 def is_gui() -> bool:

--- a/tests/keyboard/refocus/refocus-after-close/main.py
+++ b/tests/keyboard/refocus/refocus-after-close/main.py
@@ -2,7 +2,6 @@
 
 import wftest as wt
 import wfutil as wu
-import os
 import signal
 
 def is_gui() -> bool:

--- a/tests/keyboard/refocus/refocus-after-close/main.py
+++ b/tests/keyboard/refocus/refocus-after-close/main.py
@@ -43,7 +43,7 @@ class WTest(wt.WayfireTest):
         self.socket.layout_views(layout)
         self.wait_for_clients(2)
 
-        os.kill(gtk3.pid, signal.SIGKILL)
+        self.send_signal(gtk3.pid, signal.SIGKILL)
         self.wait_for_clients(2)
         if not gtk1.expect_line("keyboard-enter"):
             return wt.Status.WRONG, 'gtk1 did not receive second enter: ' + gtk1.last_line

--- a/tests/keyboard/refocus/refocus-keeps-grab/main.py
+++ b/tests/keyboard/refocus/refocus-keeps-grab/main.py
@@ -2,7 +2,6 @@
 
 import wftest as wt
 import wfutil as wu
-import os
 import signal
 
 def is_gui() -> bool:

--- a/tests/keyboard/refocus/refocus-keeps-grab/main.py
+++ b/tests/keyboard/refocus/refocus-keeps-grab/main.py
@@ -37,7 +37,7 @@ class WTest(wt.WayfireTest):
         if not gtk2.expect_line("keyboard-leave"):
             return wt.Status.WRONG, 'gtk2 did not receive leave: ' + gtk2.last_line
 
-        os.kill(gtk2.pid, signal.SIGINT)
+        self.send_signal(gtk2.pid, signal.SIGINT)
         self.wait_for_clients(2)
 
         self._click_on(self.socket.get_view_info_title('gtk1'))

--- a/tests/multi-output/noop-output/main.py
+++ b/tests/multi-output/noop-output/main.py
@@ -39,7 +39,7 @@ class WTest(wt.WayfireTest):
             return wt.Status.WRONG, 'Demo app has wrong size on NOOP-1: ' + str(cs_geometry)
 
         # Trigger damage, move cursor, any action to see that wayfire can handle it
-        os.kill(pid, signal.SIGUSR1)
+        self.send_signal(pid, signal.SIGUSR1)
         self.socket.move_cursor(10, 10)
         self.wait_for_clients(2)
         if self._get_views() != ['cs', 'layer-shell']:

--- a/tests/multi-output/noop-output/main.py
+++ b/tests/multi-output/noop-output/main.py
@@ -2,7 +2,6 @@
 
 import wfipclib as wi
 import wftest as wt
-import os
 import signal
 
 def is_gui() -> bool:

--- a/tests/plugins/animate/close-layer-shell/main.py
+++ b/tests/plugins/animate/close-layer-shell/main.py
@@ -17,7 +17,7 @@ class WTest(wt.WayfireTest):
         pid = self.socket.run('wleird-layer-shell')['pid']
         self.wait_for_clients()
 
-        os.kill(pid, signal.SIGINT)
+        self.send_signal(pid, signal.SIGINT)
         self.wait_ms(200)
 
         if len(self.socket.list_views()) > 0:

--- a/tests/plugins/animate/close-layer-shell/main.py
+++ b/tests/plugins/animate/close-layer-shell/main.py
@@ -1,7 +1,6 @@
 #!/bin/env python3
 
 import wftest as wt
-import os
 import signal
 
 def is_gui() -> bool:

--- a/tests/plugins/blur/dragged-view/main.py
+++ b/tests/plugins/blur/dragged-view/main.py
@@ -49,7 +49,7 @@ class WTest(wt.WayfireTest):
         if error := self.take_screenshot('in-flight'):
             return wt.Status.CRASHED, error
 
-        os.kill(wt_pid, signal.SIGKILL)
+        self.send_signal(wt_pid, signal.SIGKILL)
         self.wait_for_clients(2)
         if error := self.take_screenshot('force-closed'):
             return wt.Status.CRASHED, error

--- a/tests/plugins/blur/dragged-view/main.py
+++ b/tests/plugins/blur/dragged-view/main.py
@@ -1,7 +1,6 @@
 #!/bin/env python3
 
 import wftest as wt
-import os
 import signal
 
 # The test requires to compare two blur images.

--- a/tests/plugins/blur/terminator-damage-behind/main.py
+++ b/tests/plugins/blur/terminator-damage-behind/main.py
@@ -1,7 +1,6 @@
 #!/bin/env python3
 
 import wftest as wt
-import os
 import signal
 
 def is_gui() -> bool:

--- a/tests/plugins/blur/terminator-damage-behind/main.py
+++ b/tests/plugins/blur/terminator-damage-behind/main.py
@@ -34,7 +34,7 @@ class WTest(wt.WayfireTest):
             return wt.Status.CRASHED, error
 
         # Damage behind terminator and see that blur expands damage
-        os.kill(gcs_pid, signal.SIGUSR1)
+        self.send_signal(gcs_pid, signal.SIGUSR1)
         self.wait_for_clients(2)
 
         if error := self.take_screenshot('final'):

--- a/tests/plugins/expo/touch-expo-gesture-activation/main.py
+++ b/tests/plugins/expo/touch-expo-gesture-activation/main.py
@@ -20,7 +20,7 @@ class WTest(wt.WayfireTest):
         return sorted([v['title'] for v in self.socket.list_views()])
 
     def _run(self):
-        gtk1 = wu.LoggedProcess(self.socket, 'gtk_logger', 'gtk1', 'touch')
+        wu.LoggedProcess(self.socket, 'gtk_logger', 'gtk1', 'touch')
         self.wait_for_clients(2)
         if self._get_views() != ['gtk1']:
             return wt.Status.WRONG, 'Demo apps did not open: ' + str(self._get_views())

--- a/tests/plugins/move/dragged-view-receives-frame-done/main.py
+++ b/tests/plugins/move/dragged-view-receives-frame-done/main.py
@@ -1,7 +1,6 @@
 #!/bin/env python3
 
 import wftest as wt
-import os
 import signal
 
 def is_gui() -> bool:

--- a/tests/plugins/move/dragged-view-receives-frame-done/main.py
+++ b/tests/plugins/move/dragged-view-receives-frame-done/main.py
@@ -25,10 +25,10 @@ class WTest(wt.WayfireTest):
         self.socket.move_cursor(200, 200)
 
         self.wait_for_clients(2)
-        os.kill(pid, signal.SIGUSR1)
+        self.send_signal(pid, signal.SIGUSR1)
         self.wait_for_clients(2)
         # Change color a second time. This forces gcs to wait for a frame done event
-        os.kill(pid, signal.SIGUSR1)
+        self.send_signal(pid, signal.SIGUSR1)
         self.wait_for_clients(2)
 
         if error := self.take_screenshot('in-drag'):
@@ -36,7 +36,7 @@ class WTest(wt.WayfireTest):
 
         self.socket.click_button('BTN_LEFT', 'release')
         self.wait_for_clients()
-        os.kill(pid, signal.SIGUSR1)
+        self.send_signal(pid, signal.SIGUSR1)
         self.wait_for_clients(2)
 
         if error := self.take_screenshot('released'):

--- a/tests/plugins/scale/wayfire-1701-2/main.py
+++ b/tests/plugins/scale/wayfire-1701-2/main.py
@@ -1,7 +1,6 @@
 #!/bin/env python3
 
 import wftest as wt
-import os
 import signal
 
 def is_gui() -> bool:

--- a/tests/plugins/scale/wayfire-1701-2/main.py
+++ b/tests/plugins/scale/wayfire-1701-2/main.py
@@ -20,7 +20,7 @@ class WTest(wt.WayfireTest):
         self.socket.press_key('KEY_S')
         self.wait_for_clients()
 
-        os.kill(pid, signal.SIGKILL)
+        self.send_signal(pid, signal.SIGKILL)
         self.wait_for_clients(10)
 
         # Open a new window

--- a/tests/plugins/scale/wayfire-1908/main.py
+++ b/tests/plugins/scale/wayfire-1908/main.py
@@ -2,7 +2,6 @@
 
 import wfutil as wu
 import wftest as wt
-import os
 import signal
 
 def is_gui() -> bool:

--- a/tests/plugins/scale/wayfire-1908/main.py
+++ b/tests/plugins/scale/wayfire-1908/main.py
@@ -32,7 +32,7 @@ class WTest(wt.WayfireTest):
         self.wait_ms(150) # Wait for animation
 
         gcs.reset_logs()
-        os.kill(gcs.pid, signal.SIGUSR1);
+        self.send_signal(gcs.pid, signal.SIGUSR1);
         self.wait_for_clients(2)
 
         try:

--- a/tests/plugins/simple-tile/wset-destruction/main.py
+++ b/tests/plugins/simple-tile/wset-destruction/main.py
@@ -1,7 +1,6 @@
 #!/bin/env python3
 
 import wftest as wt
-import os
 import signal
 
 def is_gui() -> bool:

--- a/tests/plugins/simple-tile/wset-destruction/main.py
+++ b/tests/plugins/simple-tile/wset-destruction/main.py
@@ -19,7 +19,7 @@ class WTest(wt.WayfireTest):
         self.wait_for_clients(2)
 
         # Close the client
-        os.kill(pid, signal.SIGKILL)
+        self.send_signal(pid, signal.SIGKILL)
         self.wait_for_clients()
 
         # Go to wset 1 => wset 2 should be cleaned up

--- a/tests/plugins/switcher/close-view-while-active/main.py
+++ b/tests/plugins/switcher/close-view-while-active/main.py
@@ -1,7 +1,6 @@
 #!/bin/env python3
 
 import wftest as wt
-import os
 import signal
 
 def is_gui() -> bool:

--- a/tests/plugins/switcher/close-view-while-active/main.py
+++ b/tests/plugins/switcher/close-view-while-active/main.py
@@ -20,7 +20,7 @@ class WTest(wt.WayfireTest):
         if error := self.take_screenshot('switcher-active'):
             return wt.Status.CRASHED, error
 
-        os.kill(wt_pid, signal.SIGKILL)
+        self.send_signal(wt_pid, signal.SIGKILL)
         self.wait_for_clients()
 
         if error := self.take_screenshot('switcher-active-one-fewer'):

--- a/tests/plugins/wm-actions/always-on-top-wsets/main.py
+++ b/tests/plugins/wm-actions/always-on-top-wsets/main.py
@@ -1,7 +1,6 @@
 #!/bin/env python3
 
 import wftest as wt
-import os
 import signal
 
 def is_gui() -> bool:

--- a/tests/plugins/wm-actions/always-on-top-wsets/main.py
+++ b/tests/plugins/wm-actions/always-on-top-wsets/main.py
@@ -24,7 +24,7 @@ class WTest(wt.WayfireTest):
         pid = self.socket.run('gtk_color_switcher')['pid']
         self.socket.run('gtk_special a')
         self.wait_for_clients(2)
-        os.kill(pid, signal.SIGUSR1)
+        self.send_signal(pid, signal.SIGUSR1)
         if self._get_views() != ['gtk_color_switcher', 'gtk_special']:
             return wt.Status.WRONG, 'Demo apps did not open!'
 

--- a/tests/plugins/wsets/close-inactive/main.py
+++ b/tests/plugins/wsets/close-inactive/main.py
@@ -18,7 +18,7 @@ class WTest(wt.WayfireTest):
         self.wait_for_clients(2)
 
         self.socket.press_key('KEY_2')
-        os.kill(pid, signal.SIGKILL)
+        self.send_signal(pid, signal.SIGKILL)
         self.wait_for_clients(2)
 
         if self.socket.list_views():

--- a/tests/plugins/wsets/close-inactive/main.py
+++ b/tests/plugins/wsets/close-inactive/main.py
@@ -1,7 +1,6 @@
 #!/bin/env python3
 
 import wftest as wt
-import os
 import signal
 
 def is_gui() -> bool:

--- a/tests/tablet/close-grabbed-surface/main.py
+++ b/tests/tablet/close-grabbed-surface/main.py
@@ -1,6 +1,5 @@
 import wfutil as wu
 import wftest as wt
-import os
 import signal
 
 def is_gui() -> bool:

--- a/tests/tablet/close-grabbed-surface/main.py
+++ b/tests/tablet/close-grabbed-surface/main.py
@@ -38,7 +38,7 @@ class WTest(wt.WayfireTest):
             gtk1.reset_logs()
             gtk2.reset_logs()
 
-            os.kill(gtk1.pid, signal.SIGKILL)
+            self.send_signal(gtk1.pid, signal.SIGKILL)
             self.wait_for_clients(2)
 
             gtk1.expect_none_throw("(after kill)")

--- a/tests/touch/plugin-breaks-implicit-grab/main.py
+++ b/tests/touch/plugin-breaks-implicit-grab/main.py
@@ -1,7 +1,6 @@
 
 #!/bin/env python3
 
-import wfipclib as wi
 import wfutil as wu
 import wftest as wt
 import shutil

--- a/tests/xdg-shell/wayfire-1720/main.py
+++ b/tests/xdg-shell/wayfire-1720/main.py
@@ -42,10 +42,10 @@ class WTest(wt.WayfireTest):
 
         self.send_signal(pid, signal.SIGKILL)
         self.wait_for_clients(2)
-
         self.socket.run('weston-terminal')
-        self.wait_for_clients(2)
-        if self._get_views() != ['', 'gtk_logger', 'nil']:
-            return wt.Status.WRONG, 'weston-terminal did not open! ' + str(self._get_views())
+        self.wait_ms(600) # wait for unmap animation to end, the unmap animation is important, weston-terminal should run while it is active
+
+        if self._get_views() != ['gtk_logger', 'nil']:
+            return wt.Status.WRONG, 'Wrong views are open: ' + str(self._get_views())
 
         return wt.Status.OK, None

--- a/tests/xdg-shell/wayfire-1720/main.py
+++ b/tests/xdg-shell/wayfire-1720/main.py
@@ -2,7 +2,6 @@
 
 import wftest as wt
 import wfutil as wu
-import os
 import signal
 
 def is_gui() -> bool:
@@ -41,7 +40,7 @@ class WTest(wt.WayfireTest):
         if self._get_views() != ['', 'gedit', 'gtk_logger']:
             return wt.Status.WRONG, 'Popup menu did not open! ' + str(self._get_views())
 
-        os.kill(pid, signal.SIGKILL)
+        self.send_signal(pid, signal.SIGKILL)
         self.wait_for_clients(2)
 
         self.socket.run('weston-terminal')

--- a/tests/xdg-shell/wayfire-1720/wayfire.ini
+++ b/tests/xdg-shell/wayfire-1720/wayfire.ini
@@ -8,5 +8,5 @@ mode=1000x500
 open_animation = none
 close_animation = fade
 enabled_for = !(type equals "toplevel")
-duration = 1000
+duration = 500
 startup_duration = 0

--- a/wfpytest/wftest.py
+++ b/wfpytest/wftest.py
@@ -47,10 +47,14 @@ class WayfireTest:
         try:
             parent = psutil.Process(parent_pid)
         except psutil.NoSuchProcess:
-            return
+            raise Exception("No such process!")
+
         children = parent.children(recursive=True)
-        for process in children:
-            process.send_signal(sig)
+        if not children:
+            os.kill(parent_pid, sig)
+        else:
+            for process in children:
+                os.kill(process.pid, sig)
 
     def wait_for_clients(self, times=1):
         time.sleep(self._ipc_duration * times) # Wait for clients to start/process events

--- a/wfpytest/wftest.py
+++ b/wfpytest/wftest.py
@@ -50,11 +50,9 @@ class WayfireTest:
             raise Exception("No such process!")
 
         children = parent.children(recursive=True)
-        if not children:
-            os.kill(parent_pid, sig)
-        else:
-            for process in children:
-                os.kill(process.pid, sig)
+        os.kill(parent_pid, sig)
+        for process in children:
+            os.kill(process.pid, sig)
 
     def wait_for_clients(self, times=1):
         time.sleep(self._ipc_duration * times) # Wait for clients to start/process events

--- a/wfpytest/wftest.py
+++ b/wfpytest/wftest.py
@@ -7,6 +7,7 @@ import wfutil as wu
 
 import subprocess
 import signal
+import psutil
 import os
 import time
 import traceback
@@ -41,6 +42,15 @@ class WayfireTest:
         self._ipc_duration = 0.1
         self.screenshots = []
         self.screenshot_prefix = ""
+
+    def send_signal(self, parent_pid, sig=signal.SIGTERM):
+        try:
+            parent = psutil.Process(parent_pid)
+        except psutil.NoSuchProcess:
+            return
+        children = parent.children(recursive=True)
+        for process in children:
+            process.send_signal(sig)
 
     def wait_for_clients(self, times=1):
         time.sleep(self._ipc_duration * times) # Wait for clients to start/process events


### PR DESCRIPTION
The tests were sending signals to /bin/sh, which often didn't make it to the children processes.