### PR TITLE
add a test for a race condition (#2445)

### DIFF
--- a/clients/meson.build
+++ b/clients/meson.build
@@ -16,6 +16,7 @@ project(
 # Dependencies
 x11 = dependency('x11')
 gtkmm = dependency('gtkmm-3.0')
+cairo = dependency('cairo')
 wayland_client = dependency('wayland-client')
 wayland_protos = dependency('wayland-protocols', version: '>=1.12')
 logger_inc = include_directories(['.'])
@@ -40,6 +41,8 @@ wayland_scanner_client = generator(
 protocols = [
     [wl_protocol_dir, 'unstable/pointer-constraints/pointer-constraints-unstable-v1.xml'],
     [wl_protocol_dir, 'unstable/tablet/tablet-unstable-v2.xml'],
+    [wl_protocol_dir, 'stable/xdg-shell/xdg-shell.xml'],
+    ['wlr-foreign-toplevel-management-unstable-v1.xml']
 ]
 
 wl_protos_src = []
@@ -101,3 +104,8 @@ executable('layer_shell_kb_popup', ['gtk_layer_shell_kb_popup.cpp'],
 executable('layer_shell_delay_exclusive', ['gtk_layer_delayed_exclusive.cpp'],
     dependencies: [gtkmm, gtklayershell],
     install: false)
+
+executable('xdg_popup_crasher', ['xdg_popup_crasher.c'],
+    dependencies: [cairo, wayland_client, wl_protos],
+    install: false)
+

--- a/clients/wlr-foreign-toplevel-management-unstable-v1.xml
+++ b/clients/wlr-foreign-toplevel-management-unstable-v1.xml
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_foreign_toplevel_management_unstable_v1">
+  <copyright>
+    Copyright © 2018 Ilia Bozhinov
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="zwlr_foreign_toplevel_manager_v1" version="3">
+    <description summary="list and control opened apps">
+      The purpose of this protocol is to enable the creation of taskbars
+      and docks by providing them with a list of opened applications and
+      letting them request certain actions on them, like maximizing, etc.
+
+      After a client binds the zwlr_foreign_toplevel_manager_v1, each opened
+      toplevel window will be sent via the toplevel event
+    </description>
+
+    <event name="toplevel">
+      <description summary="a toplevel has been created">
+        This event is emitted whenever a new toplevel window is created. It
+        is emitted for all toplevels, regardless of the app that has created
+        them.
+
+        All initial details of the toplevel(title, app_id, states, etc.) will
+        be sent immediately after this event via the corresponding events in
+        zwlr_foreign_toplevel_handle_v1.
+      </description>
+      <arg name="toplevel" type="new_id" interface="zwlr_foreign_toplevel_handle_v1"/>
+    </event>
+
+    <request name="stop">
+      <description summary="stop sending events">
+        Indicates the client no longer wishes to receive events for new toplevels.
+        However the compositor may emit further toplevel_created events, until
+        the finished event is emitted.
+
+        The client must not send any more requests after this one.
+      </description>
+    </request>
+
+    <event name="finished">
+      <description summary="the compositor has finished with the toplevel manager">
+        This event indicates that the compositor is done sending events to the
+        zwlr_foreign_toplevel_manager_v1. The server will destroy the object
+        immediately after sending this request, so it will become invalid and
+        the client should free any resources associated with it.
+      </description>
+    </event>
+  </interface>
+
+  <interface name="zwlr_foreign_toplevel_handle_v1" version="3">
+    <description summary="an opened toplevel">
+      A zwlr_foreign_toplevel_handle_v1 object represents an opened toplevel
+      window. Each app may have multiple opened toplevels.
+
+      Each toplevel has a list of outputs it is visible on, conveyed to the
+      client with the output_enter and output_leave events.
+    </description>
+
+    <event name="title">
+      <description summary="title change">
+        This event is emitted whenever the title of the toplevel changes.
+      </description>
+      <arg name="title" type="string"/>
+    </event>
+
+    <event name="app_id">
+      <description summary="app-id change">
+        This event is emitted whenever the app-id of the toplevel changes.
+      </description>
+      <arg name="app_id" type="string"/>
+    </event>
+
+    <event name="output_enter">
+      <description summary="toplevel entered an output">
+        This event is emitted whenever the toplevel becomes visible on
+        the given output. A toplevel may be visible on multiple outputs.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+    </event>
+
+    <event name="output_leave">
+      <description summary="toplevel left an output">
+        This event is emitted whenever the toplevel stops being visible on
+        the given output. It is guaranteed that an entered-output event
+        with the same output has been emitted before this event.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+    </event>
+
+    <request name="set_maximized">
+      <description summary="requests that the toplevel be maximized">
+        Requests that the toplevel be maximized. If the maximized state actually
+        changes, this will be indicated by the state event.
+      </description>
+    </request>
+
+    <request name="unset_maximized">
+      <description summary="requests that the toplevel be unmaximized">
+        Requests that the toplevel be unmaximized. If the maximized state actually
+        changes, this will be indicated by the state event.
+      </description>
+    </request>
+
+    <request name="set_minimized">
+      <description summary="requests that the toplevel be minimized">
+        Requests that the toplevel be minimized. If the minimized state actually
+        changes, this will be indicated by the state event.
+      </description>
+    </request>
+
+    <request name="unset_minimized">
+      <description summary="requests that the toplevel be unminimized">
+        Requests that the toplevel be unminimized. If the minimized state actually
+        changes, this will be indicated by the state event.
+      </description>
+    </request>
+
+    <request name="activate">
+      <description summary="activate the toplevel">
+        Request that this toplevel be activated on the given seat.
+        There is no guarantee the toplevel will be actually activated.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat"/>
+    </request>
+
+    <enum name="state">
+      <description summary="types of states on the toplevel">
+        The different states that a toplevel can have. These have the same meaning
+        as the states with the same names defined in xdg-toplevel
+      </description>
+
+      <entry name="maximized"  value="0" summary="the toplevel is maximized"/>
+      <entry name="minimized"  value="1" summary="the toplevel is minimized"/>
+      <entry name="activated"  value="2" summary="the toplevel is active"/>
+      <entry name="fullscreen" value="3" summary="the toplevel is fullscreen" since="2"/>
+    </enum>
+
+    <event name="state">
+      <description summary="the toplevel state changed">
+        This event is emitted immediately after the zlw_foreign_toplevel_handle_v1
+        is created and each time the toplevel state changes, either because of a
+        compositor action or because of a request in this protocol.
+      </description>
+
+      <arg name="state" type="array"/>
+    </event>
+
+    <event name="done">
+      <description summary="all information about the toplevel has been sent">
+        This event is sent after all changes in the toplevel state have been
+        sent.
+
+        This allows changes to the zwlr_foreign_toplevel_handle_v1 properties
+        to be seen as atomic, even if they happen via multiple events.
+      </description>
+    </event>
+
+    <request name="close">
+      <description summary="request that the toplevel be closed">
+        Send a request to the toplevel to close itself. The compositor would
+        typically use a shell-specific method to carry out this request, for
+        example by sending the xdg_toplevel.close event. However, this gives
+        no guarantees the toplevel will actually be destroyed. If and when
+        this happens, the zwlr_foreign_toplevel_handle_v1.closed event will
+        be emitted.
+      </description>
+    </request>
+
+    <request name="set_rectangle">
+      <description summary="the rectangle which represents the toplevel">
+        The rectangle of the surface specified in this request corresponds to
+        the place where the app using this protocol represents the given toplevel.
+        It can be used by the compositor as a hint for some operations, e.g
+        minimizing. The client is however not required to set this, in which
+        case the compositor is free to decide some default value.
+
+        If the client specifies more than one rectangle, only the last one is
+        considered.
+
+        The dimensions are given in surface-local coordinates.
+        Setting width=height=0 removes the already-set rectangle.
+      </description>
+
+      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="x" type="int"/>
+      <arg name="y" type="int"/>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </request>
+
+    <enum name="error">
+      <entry name="invalid_rectangle" value="0"
+        summary="the provided rectangle is invalid"/>
+    </enum>
+
+    <event name="closed">
+      <description summary="this toplevel has been destroyed">
+        This event means the toplevel has been destroyed. It is guaranteed there
+        won't be any more events for this zwlr_foreign_toplevel_handle_v1. The
+        toplevel itself becomes inert so any requests will be ignored except the
+        destroy request.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the zwlr_foreign_toplevel_handle_v1 object">
+        Destroys the zwlr_foreign_toplevel_handle_v1 object.
+
+        This request should be called either when the client does not want to
+        use the toplevel anymore or after the closed event to finalize the
+        destruction of the object.
+      </description>
+    </request>
+
+    <!-- Version 2 additions -->
+
+    <request name="set_fullscreen" since="2">
+      <description summary="request that the toplevel be fullscreened">
+        Requests that the toplevel be fullscreened on the given output. If the
+        fullscreen state and/or the outputs the toplevel is visible on actually
+        change, this will be indicated by the state and output_enter/leave
+        events.
+
+        The output parameter is only a hint to the compositor. Also, if output
+        is NULL, the compositor should decide which output the toplevel will be
+        fullscreened on, if at all.
+      </description>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+    </request>
+
+    <request name="unset_fullscreen" since="2">
+      <description summary="request that the toplevel be unfullscreened">
+        Requests that the toplevel be unfullscreened. If the fullscreen state
+        actually changes, this will be indicated by the state event.
+      </description>
+    </request>
+
+    <!-- Version 3 additions -->
+
+    <event name="parent" since="3">
+      <description summary="parent change">
+        This event is emitted whenever the parent of the toplevel changes.
+      </description>
+      <arg name="parent" type="object" interface="zwlr_foreign_toplevel_handle_v1" allow-null="true"/>
+    </event>
+  </interface>
+</protocol>

--- a/clients/xdg_popup_crasher.c
+++ b/clients/xdg_popup_crasher.c
@@ -1,0 +1,488 @@
+/*
+ * wlr-crasher.c -- simple program to demonstrate a crash in wlroots
+ * 	(based on wlroots examples)
+ * 
+ * 2020-2024 Daniel Kondor <kondor.dani@gmail.com>
+ */
+
+#define WLR_USE_UNSTABLE
+#define _GNU_SOURCE         /* See feature_test_macros(7) */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+
+#include <sys/mman.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include <wayland-client.h>
+#include <wayland-server.h>
+#include <cairo.h>
+#include "xdg-shell-client-protocol.h"
+#include "wlr-foreign-toplevel-management-unstable-v1-client-protocol.h"
+
+
+#define UNUSED __attribute__((unused))
+
+static int width = 400, height = 300;
+static int popup_width = 300, popup_height = 300;
+static int is_child = 0;
+
+static struct wl_display* display = NULL;
+static struct wl_compositor* compositor = NULL;
+static struct wl_seat* seat = NULL;
+static struct wl_shm* wl_shm = NULL;
+static struct xdg_wm_base* wm_base = NULL;
+static struct zwlr_foreign_toplevel_manager_v1* toplevel_manager = NULL;
+
+typedef struct zwlr_foreign_toplevel_handle_v1 wfthandle;
+
+static struct wl_surface* surface = NULL;
+static struct xdg_toplevel* toplevel = NULL;
+static struct wl_surface* popup_surface = NULL;
+static struct xdg_popup* popup = NULL;
+
+static int pointer_popup = 0;
+
+static wfthandle* child_handle = NULL;
+
+static const char parent_app_id[] = "wlr-crasher-parent";
+static const char child_app_id[] = "wlr-crasher-child";
+
+
+static useconds_t sleep_interval = 5000;
+static bool do_flush = false;
+
+static bool auto_run = false; // run everything automatically
+
+
+// callbacks 
+void toplevel_title_cb(UNUSED void *data, UNUSED wfthandle *handle, UNUSED const char *title) {
+	/* we don't care */
+}
+
+void toplevel_appid_cb(UNUSED void *data, wfthandle *handle, const char *app_id) {
+	/* set our handle to the child */
+	if(app_id && !child_handle && !strcmp(app_id, child_app_id)) {
+		child_handle = handle;
+		fprintf(stderr, "Child found\n");
+	}
+	/* otherwise we don't care */
+	else zwlr_foreign_toplevel_handle_v1_destroy(handle);
+}
+
+void toplevel_output_enter_cb(UNUSED void *data, UNUSED wfthandle *handle, UNUSED struct wl_output *output) {
+	/* we don't care */
+}
+void toplevel_output_leave_cb(UNUSED void *data, UNUSED wfthandle *handle, UNUSED struct wl_output *output) {
+	/* we don't care */
+}
+
+void toplevel_state_cb(UNUSED void *data, UNUSED wfthandle *handle, UNUSED struct wl_array *state) {
+	/* we don't care */
+}
+
+void toplevel_done_cb(UNUSED void *data, UNUSED wfthandle *handle) {
+	/* we don't care */
+}
+
+void toplevel_parent_cb(UNUSED void *data, UNUSED wfthandle *handle, wfthandle*) {
+	/* we don't care */
+}
+
+void toplevel_closed_cb (UNUSED void *data, UNUSED wfthandle *handle) {
+	if(handle == child_handle) {
+		child_handle = NULL;
+		fprintf(stderr, "Child lost\n");
+	}
+	zwlr_foreign_toplevel_handle_v1_destroy(handle);
+}
+
+struct zwlr_foreign_toplevel_handle_v1_listener toplevel_handle_listener = {
+    .title        = toplevel_title_cb,
+    .app_id       = toplevel_appid_cb,
+    .output_enter = toplevel_output_enter_cb,
+    .output_leave = toplevel_output_leave_cb,
+    .state        = toplevel_state_cb,
+    .done         = toplevel_done_cb,
+    .closed       = toplevel_closed_cb,
+    .parent       = toplevel_parent_cb
+};
+
+static void new_toplevel (UNUSED void *data,
+		UNUSED struct zwlr_foreign_toplevel_manager_v1 *manager,
+		wfthandle *handle) {
+	/* note: we cannot do anything as long as we get app_id */
+	zwlr_foreign_toplevel_handle_v1_add_listener (handle, &toplevel_handle_listener, NULL);
+}
+
+static void toplevel_manager_finished(UNUSED void *data, UNUSED struct zwlr_foreign_toplevel_manager_v1 *manager) {
+	/* don't care */
+}
+
+static struct zwlr_foreign_toplevel_manager_v1_listener toplevel_manager_listener = {
+    .toplevel = new_toplevel,
+    .finished = toplevel_manager_finished,
+};
+
+
+static int shm_create(size_t size) {
+    int shm_fd = memfd_create("wlrc", MFD_CLOEXEC);
+    if(shm_fd < 0) return -1;
+    int ret;
+    errno = 0;
+    do { ret = ftruncate(shm_fd, size); } while (ret < 0 && errno == EINTR);
+    if (ret < 0) {
+        close(shm_fd);
+        return -1;
+    }
+    return shm_fd;
+}
+
+static void wl_buffer_release(UNUSED void *data, struct wl_buffer *wl_buffer) {
+	wl_buffer_destroy(wl_buffer);
+}
+
+static const struct wl_buffer_listener buffer_listener = {
+	.release = wl_buffer_release,
+};
+
+static void render_frame(struct wl_surface* wls) {
+	int w = (wls == popup_surface) ? popup_width : width;
+	int h = (wls == popup_surface) ? popup_height : height;
+	if(!w) w = 400;
+	if(!h) h = 300;
+	int stride = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, w);
+	size_t size = stride * h * 4;
+	int shm_fd = shm_create(size);
+	if(shm_fd < 0) goto render_frame_error;
+	unsigned char *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd, 0);
+    if(data == MAP_FAILED) {
+		close(shm_fd);
+		goto render_frame_error;
+    }
+	
+	struct wl_shm_pool* pool = wl_shm_create_pool(wl_shm, shm_fd, size);
+	struct wl_buffer* buffer = NULL;
+	if(pool) {
+		buffer = wl_shm_pool_create_buffer(pool, 0, w, h, stride, WL_SHM_FORMAT_ARGB8888);
+		wl_shm_pool_destroy(pool);
+	}
+	close(shm_fd);
+	if(!buffer) goto render_frame_error;
+	
+	cairo_surface_t* csurface = cairo_image_surface_create_for_data(data, CAIRO_FORMAT_ARGB32, w, h, stride);
+	cairo_t* cr = cairo_create(csurface);
+	cairo_set_source_rgba(cr, 0, 0, wls == popup_surface ? 0.7 : 0, 1);
+	cairo_paint(cr);
+	cairo_select_font_face(cr, "sans-serif", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
+	cairo_set_font_size(cr, 14);
+	cairo_set_source_rgba(cr, 1, 1, 1, 1);
+	cairo_move_to(cr, 50, 150);
+	cairo_show_text(cr, is_child ? "Crasher child process   (click to exit)" :
+		(wls == popup_surface ? "Click me to crash" : "Crasher parent process   (click to exit)"));
+	cairo_surface_flush(csurface);
+	
+	wl_buffer_add_listener(buffer, &buffer_listener, NULL);
+	
+	wl_surface_attach(wls, buffer, 0, 0);
+	wl_surface_commit(wls);
+	
+	cairo_destroy(cr);
+    cairo_surface_destroy(csurface);
+	
+	munmap(data, size);
+	
+    return;
+	
+render_frame_error:
+	fprintf(stderr, "Cannot create shared memory for rendering!\n");
+}
+
+static void xdg_surface_handle_configure(void *data,
+		struct xdg_surface *xdg_surface, uint32_t serial) {
+	xdg_surface_ack_configure(xdg_surface, serial);
+	
+	render_frame((struct wl_surface*)data);
+}
+
+static const struct xdg_surface_listener xdg_surface_listener = {
+	.configure = xdg_surface_handle_configure,
+};
+
+static void xdg_toplevel_handle_configure(UNUSED void *data,
+		UNUSED struct xdg_toplevel *xdg_toplevel, int32_t w, int32_t h,
+		UNUSED struct wl_array *states) {
+	width = w;
+	height = h;
+}
+
+static void xdg_toplevel_handle_close(UNUSED void *data,
+		UNUSED struct xdg_toplevel *xdg_toplevel) {
+	exit(0);
+}
+
+static const struct xdg_toplevel_listener xdg_toplevel_listener = {
+	.configure = xdg_toplevel_handle_configure,
+	.close = xdg_toplevel_handle_close,
+};
+
+static void xdg_popup_handle_configure(UNUSED void* data,
+		UNUSED struct xdg_popup *xdg_toplevel, UNUSED int32_t x,
+		UNUSED int32_t y, int32_t w, int32_t h) {
+	popup_width = w;
+	popup_height = h;
+}
+
+static void xdg_popup_handle_done(UNUSED void* data, struct xdg_popup* popup1) {
+	fprintf(stderr, "\n\n\nDestroying popup\n\n\n");
+	xdg_popup_destroy(popup1);
+	popup = NULL;
+}
+
+static const struct xdg_popup_listener xdg_popup_listener = {
+	.configure = xdg_popup_handle_configure,
+	.popup_done = xdg_popup_handle_done
+};
+
+
+static void xdg_wm_base_ping(UNUSED void *data, struct xdg_wm_base *xdg_wm_base, uint32_t serial) {
+    xdg_wm_base_pong(xdg_wm_base, serial);
+}
+
+static const struct xdg_wm_base_listener xdg_wm_base_listener = {
+    .ping = xdg_wm_base_ping,
+};
+
+
+static void pointer_handle_button(UNUSED void *data, UNUSED struct wl_pointer *pointer, UNUSED uint32_t serial,
+		UNUSED uint32_t time, UNUSED uint32_t button, uint32_t state_w) {
+	if(!state_w) return;
+	if(pointer_popup) {
+		if(child_handle) {
+			fprintf(stderr, "\n\n\nSending activate, this should close the popup\n");
+			zwlr_foreign_toplevel_handle_v1_activate(child_handle, seat);
+			if(do_flush) wl_display_flush(display);
+			if(sleep_interval) usleep(sleep_interval);
+			fprintf(stderr, "\n\n\nSetting the minimize position for the child\n\n\n");
+			zwlr_foreign_toplevel_handle_v1_set_rectangle(child_handle, popup_surface, 0, 0, 1, 1);
+/*			fprintf(stderr, "\n\n\nCommiting the popup\n\n\n");
+			render_frame(popup_surface); */
+		}
+		else fprintf(stderr, "\n\n\nNo child present, doing nothing\n");
+	}
+	else exit(0);
+}
+
+static void pointer_handle_enter(UNUSED void *data, UNUSED struct wl_pointer *wl_pointer,
+		UNUSED uint32_t serial, struct wl_surface *surface,
+		UNUSED wl_fixed_t surface_x,UNUSED  wl_fixed_t surface_y) {
+	if(surface == popup_surface) pointer_popup = 1;
+	else pointer_popup = 0;
+}
+
+static void pointer_handle_leave(UNUSED void *data, UNUSED struct wl_pointer *wl_pointer,
+		UNUSED uint32_t serial, struct wl_surface *surface) {
+	if(surface == popup_surface) pointer_popup = 0;
+}
+
+static void pointer_handle_motion(UNUSED void *data, UNUSED struct wl_pointer *wl_pointer,
+		UNUSED uint32_t time, UNUSED wl_fixed_t surface_x, UNUSED wl_fixed_t surface_y) {
+	// This space intentionally left blank
+}
+
+static void pointer_handle_axis(UNUSED void *data, UNUSED struct wl_pointer *wl_pointer,
+		UNUSED uint32_t time, UNUSED uint32_t axis, UNUSED wl_fixed_t value) {
+	// This space intentionally left blank
+}
+
+static void pointer_handle_frame(UNUSED void *data, UNUSED struct wl_pointer *wl_pointer) {
+	// This space intentionally left blank
+}
+
+static void pointer_handle_axis_source(UNUSED void *data,
+		UNUSED struct wl_pointer *wl_pointer, UNUSED uint32_t axis_source) {
+	// This space intentionally left blank
+}
+
+static void pointer_handle_axis_stop(UNUSED void *data,
+		UNUSED struct wl_pointer *wl_pointer, UNUSED uint32_t time, UNUSED uint32_t axis) {
+	// This space intentionally left blank
+}
+
+static void pointer_handle_axis_discrete(UNUSED void *data,
+		UNUSED struct wl_pointer *wl_pointer, UNUSED uint32_t axis, UNUSED int32_t discrete) {
+	// This space intentionally left blank
+}
+
+static const struct wl_pointer_listener pointer_listener = {
+	.enter = pointer_handle_enter,
+	.leave = pointer_handle_leave,
+	.motion = pointer_handle_motion,
+	.button = pointer_handle_button,
+	.axis = pointer_handle_axis,
+	.frame = pointer_handle_frame,
+	.axis_source = pointer_handle_axis_source,
+	.axis_stop = pointer_handle_axis_stop,
+	.axis_discrete = pointer_handle_axis_discrete,
+};
+
+
+
+static void handle_global(UNUSED void *data, struct wl_registry *registry,
+		uint32_t name, const char *interface, uint32_t version) {
+	if(strcmp(interface, wl_compositor_interface.name) == 0) {
+		compositor = wl_registry_bind(registry, name,
+			&wl_compositor_interface, 1);
+	} else if(strcmp(interface, xdg_wm_base_interface.name) == 0) {
+		wm_base = wl_registry_bind(registry, name, &xdg_wm_base_interface, 1);
+		xdg_wm_base_add_listener(wm_base, &xdg_wm_base_listener, NULL);
+	} else if(!is_child && strcmp(interface,
+			zwlr_foreign_toplevel_manager_v1_interface.name) == 0) {
+		toplevel_manager = wl_registry_bind(registry, name,
+			&zwlr_foreign_toplevel_manager_v1_interface, version);
+	} else if(strcmp(interface, wl_seat_interface.name) == 0) {
+		seat = wl_registry_bind(registry, name, &wl_seat_interface, 2);
+	} else if(strcmp(interface, wl_shm_interface.name) == 0) {
+        wl_shm = wl_registry_bind(registry, name, &wl_shm_interface, 1);
+	}
+}
+
+static void handle_global_remove(UNUSED void *data,UNUSED  struct wl_registry *registry,UNUSED  uint32_t name) {
+	// who cares
+}
+
+static const struct wl_registry_listener registry_listener = {
+	.global = handle_global,
+	.global_remove = handle_global_remove,
+};
+
+int main(int argc, char **argv)
+{
+	int i;
+	int create_child = 1;
+	for(i = 1; i < argc; i++) {
+		if(argv[i][0] == '-') switch(argv[i][1]) {
+			case 's':
+				sleep_interval = atoi(argv[i+1]);
+				i++;
+				break;
+			case 'C':
+				create_child = 0;
+				break;
+			case 'F':
+				do_flush = true;
+				break;
+			case 'a':
+				auto_run = true;
+				break;
+			default:
+				fprintf(stderr, "Unknown parameter: %s!\n", argv[i]);
+				break;
+		}
+		else fprintf(stderr, "Unknown parameter: %s!\n", argv[i]);		
+	}
+	
+	if(create_child) {
+		int pid = fork();
+		if(pid < 0) {
+			fprintf(stderr, "Error creating child process!\n");
+			return 1;
+		}
+		is_child = pid ? 0 : 1;
+		if(is_child) {
+			/* we don't want the child's debug messages */
+			int fd = open("/dev/null", O_CLOEXEC | O_WRONLY);
+			dup2(fd, STDOUT_FILENO);
+			dup2(fd, STDERR_FILENO);
+		}
+	}
+	
+	display = wl_display_connect(NULL);
+	assert(display);
+	struct wl_registry *registry = wl_display_get_registry(display);
+	assert(registry);
+	wl_registry_add_listener(registry, &registry_listener, NULL);
+	wl_display_roundtrip(display);
+	assert(compositor && seat && wm_base && wl_shm && (is_child || toplevel_manager));
+	
+	if(!is_child) {
+		zwlr_foreign_toplevel_manager_v1_add_listener(toplevel_manager, &toplevel_manager_listener, NULL);
+		// wait until the child view is displayed (so that we can take focus)
+		while (!child_handle && wl_display_dispatch(display) != -1);
+		if (!child_handle) {
+			fprintf(stderr, "Cannot find child view!\n");
+			return 1;
+		}
+	}
+	
+	struct wl_pointer *pointer = wl_seat_get_pointer(seat);
+	wl_pointer_add_listener(pointer, &pointer_listener, NULL);
+	
+	surface = wl_compositor_create_surface(compositor);
+	assert(surface);
+	struct xdg_surface *xdg_surface = xdg_wm_base_get_xdg_surface(wm_base, surface);
+	assert(xdg_surface);
+	struct xdg_toplevel *xdg_toplevel = xdg_surface_get_toplevel(xdg_surface);
+	assert(xdg_toplevel);
+	toplevel = xdg_toplevel;
+	
+	xdg_surface_add_listener(xdg_surface, &xdg_surface_listener, surface);
+	xdg_toplevel_add_listener(xdg_toplevel, &xdg_toplevel_listener, surface);
+	
+	xdg_toplevel_set_title(xdg_toplevel, is_child ? "wlr-crasher child" : "wlr-crasher parent");
+	xdg_toplevel_set_app_id(xdg_toplevel, is_child ? child_app_id : parent_app_id);
+	
+	wl_surface_commit(surface);
+	
+	wl_display_roundtrip(display);
+	// render_frame();
+	
+	if(!is_child) {
+		struct xdg_positioner* positioner = xdg_wm_base_create_positioner(wm_base);
+		assert(positioner);
+		xdg_positioner_set_size(positioner, popup_width, popup_height);
+		xdg_positioner_set_anchor_rect(positioner, 0, 200, 1, 1);
+		xdg_positioner_set_anchor(positioner, 5);
+		xdg_positioner_set_gravity(positioner, 2);
+		
+		popup_surface = wl_compositor_create_surface(compositor);
+		assert(popup_surface);
+		struct xdg_surface* popup_xdg_surface = xdg_wm_base_get_xdg_surface(wm_base, popup_surface);
+		assert(popup_xdg_surface);
+		popup = xdg_surface_get_popup(popup_xdg_surface, xdg_surface, positioner);
+		assert(popup);
+		
+		xdg_surface_add_listener(popup_xdg_surface, &xdg_surface_listener, popup_surface);
+		xdg_popup_add_listener(popup, &xdg_popup_listener, popup_surface);
+		
+		wl_surface_commit(popup_surface);
+		xdg_positioner_destroy(positioner);
+		wl_display_roundtrip(display);
+	}
+	
+	if (!is_child && auto_run)
+	{
+		wl_display_dispatch(display);
+		// trigger the activation that results in a crash
+		pointer_popup = true;
+		pointer_handle_button(NULL, NULL, 0, 0, 0, 1);
+	}
+	while (wl_display_dispatch(display) != -1) {
+		if (auto_run && !is_child && !popup)
+		{
+			// if our popup was successfully closed, exit both the child and us
+			if (child_handle) zwlr_foreign_toplevel_handle_v1_close(child_handle);
+			wl_display_roundtrip(display);
+			break;
+		}
+	}
+	
+	return 0;
+}
+

--- a/tests/xdg-popup-race/main.py
+++ b/tests/xdg-popup-race/main.py
@@ -1,0 +1,17 @@
+#!/bin/env python3
+
+import wftest as wt
+
+def is_gui() -> bool:
+    return False
+
+# Start scale, check that keyboard keys actually work
+class WTest(wt.WayfireTest):
+    def prepare(self):
+        return self.require_test_clients(['xdg_popup_crasher'])
+
+    def _run(self):
+        self.socket.run('xdg_popup_crasher -a')
+        self.wait_for_clients(10)
+
+        return wt.Status.OK, None

--- a/tests/xdg-popup-race/wayfire.ini
+++ b/tests/xdg-popup-race/wayfire.ini
@@ -1,0 +1,2 @@
+[core]
+plugins = ipc ipc-rules stipc foreign-toplevel


### PR DESCRIPTION
Test for https://github.com/WayfireWM/wayfire/issues/2445

Slightly modified version of https://github.com/dkondor/xdg_popup_crasher to not require user input and crash more reliably.
The test is only about whether Wayfire crashes -- I'm not sure if I'm handling it correctly, it should ideally wait for the client to exit before reporting success. For me it works: it crashes (and reports failure) with the master branch and passes succesfully with the [fix](https://github.com/WayfireWM/wayfire/pull/2531) applied.
